### PR TITLE
Update rack because a security issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       memoist (~> 0.14)
       padrino-helpers (~> 0.13.0)
       parallel
-      rack (>= 1.4.5, < 3)
+      rack (>= 2.0.6, < 3)
       sass (>= 3.4)
       servolux
       tilt (~> 2.0)
@@ -86,7 +86,7 @@ GEM
       activesupport (>= 3.1)
     parallel (1.12.0)
     public_suffix (3.0.0)
-    rack (2.0.3)
+    rack (2.0.6)
     rack-livereload (0.3.17)
       rack
     rb-fsevent (0.10.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       memoist (~> 0.14)
       padrino-helpers (~> 0.13.0)
       parallel
-      rack (>= 2.0.6, < 3)
+      rack (>= 1.4.5, < 3)
       sass (>= 3.4)
       servolux
       tilt (~> 2.0)


### PR DESCRIPTION
[CVE-2018-16471 ](https://nvd.nist.gov/vuln/detail/CVE-2018-16471)
**Vulnerable versions**: >= 2.0.0, < 2.0.6
**Patched version**: 2.0.6
There is a possible XSS vulnerability in Rack before 2.0.6 and 1.6.11. Carefully crafted requests can impact the data returned by the scheme method on Rack::Request. Applications that expect the scheme to be limited to 'http' or 'https' and do not escape the return value could be vulnerable to an XSS attack. Note that applications using the normal escaping mechanisms provided by Rails may not be impacted, but applications that bypass the escaping mechanisms, or do not use them may be vulnerable.

[CVE-2018-16470](https://nvd.nist.gov/vuln/detail/CVE-2018-16470)
**Vulnerable versions**: >= 2.0.4, < 2.0.6
**Patched version**: 2.0.6
There is a possible DoS vulnerability in the multipart parser in Rack before 2.0.6. Specially crafted requests can cause the multipart parser to enter a pathological state, causing the parser to use CPU resources disproportionate to the request size.